### PR TITLE
Update to latest libmachine/*.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 docker-machine-driver-dind*
+/vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5
+FROM golang:1.6
 
 ENV REPO github.com/nathanleclaire/docker-machine-dind
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/nathanleclaire/docker-machine-driver-dind",
-	"GoVersion": "go1.5.1",
+	"GoVersion": "go1.6",
 	"Deps": [
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
@@ -18,33 +18,33 @@
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/drivers",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/log",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcnflag",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcnutils",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/ssh",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/state",
-			"Comment": "v0.5.0-22-g6be950f",
-			"Rev": "6be950f1c0541ae269731aca02972acb2d537645"
+			"Comment": "v0.6.0-rc4-76-g8046e13",
+			"Rev": "8046e13683f6c40cfa55ae106bba5f4f4d87f7ea"
 		},
 		{
 			"ImportPath": "github.com/samalba/dockerclient",


### PR DESCRIPTION
This clears an API break in libmachine/drivers going from 0.5.0 -> 0.5.1 (https://github.com/docker/machine/issues/2325)
and gets the dind plugin working with the current docker stack.

The change also bumps to go 1.6.

Signed-off-by: John Sirois john.sirois@gmail.com
