### PR TITLE
Latest dockerclient library's CreateContainer requires 3rd parameter

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -115,7 +115,7 @@ func (d *Driver) Create() error {
 		},
 	}
 
-	id, err := dc.CreateContainer(containerConfig, d.MachineName)
+	id, err := dc.CreateContainer(containerConfig, d.MachineName, nil)
 	if err != nil {
 		return fmt.Errorf("Error creating container: %s", err)
 	}


### PR DESCRIPTION
Testing my version bump with this external driver. Found a small problem, one-liner fix.
